### PR TITLE
Add reverse proxy path support and auto-login credentials injection

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/da.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/da.json
@@ -161,5 +161,13 @@
   "insufficientSpace": "Din enhed har ikke nok plads. Fjern nogle apps og prøv igen...",
   "lblKeepWGTFile": "Bevar WGT-fil",
   "AuthorMismatch": "Forfattercertifikat stemmer ikke overens. Underskriv venligst pakken igen med det korrekte certifikat.",
-  "FixYouTube153": "Ret YouTube-plugin (fejl 153)"
+  "FixYouTube153": "Ret YouTube-plugin (fejl 153)",
+  "lblBasePath": "Basissti",
+  "lblJellyfinUsername": "Brugernavn",
+  "lblJellyfinPassword": "Adgangskode",
+  "lblAuthenticate": "Log ind",
+  "lblAutoLoginSettings": "Auto-login indstillinger",
+  "lblBasePathHint": "Tip: Indsæt fuld URL (f.eks. https://host.com/sti/jellyfin) for at udfylde alle felter automatisk",
+  "lblTestServer": "Test server",
+  "lblEnableAutoLoginConfig": "Aktivér config-patching for auto-login"
 }

--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/de.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/de.json
@@ -161,5 +161,13 @@
   "insufficientSpace": "Auf Ihrem Gerät ist nicht genügend Speicherplatz vorhanden. Bitte entfernen Sie einige Apps und versuchen Sie es erneut ...",
   "lblKeepWGTFile": "WGT-Datei beibehalten",
   "AuthorMismatch": "Das Autorenzertifikat stimmt nicht überein. Bitte signieren Sie das Paket erneut mit dem richtigen Zertifikat.",
-  "FixYouTube153": "YouTube-Plugin reparieren (Fehler 153)"
+  "FixYouTube153": "YouTube-Plugin reparieren (Fehler 153)",
+  "lblBasePath": "Basispfad",
+  "lblJellyfinUsername": "Benutzername",
+  "lblJellyfinPassword": "Passwort",
+  "lblAuthenticate": "Anmelden",
+  "lblAutoLoginSettings": "Auto-Login-Einstellungen",
+  "lblBasePathHint": "Tipp: Vollständige URL einfügen (z.B. https://host.com/pfad/jellyfin) um alle Felder automatisch auszufüllen",
+  "lblTestServer": "Server testen",
+  "lblEnableAutoLoginConfig": "Config-Patching für Auto-Login aktivieren"
 }

--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
@@ -161,5 +161,13 @@
   "insufficientSpace": "Your device has insufficient space, please remove some apps and try again...",
   "lblKeepWGTFile": "Preserve WGT file",
   "AuthorMismatch": "Author Certificate mismatch, please re-sign the package with correct certificate.",
-  "FixYouTube153": "Fix YouTube Plugin (Error 153)"
+  "FixYouTube153": "Fix YouTube Plugin (Error 153)",
+  "lblBasePath": "Base Path",
+  "lblJellyfinUsername": "Username",
+  "lblJellyfinPassword": "Password",
+  "lblAuthenticate": "Login",
+  "lblAutoLoginSettings": "Auto-Login Settings",
+  "lblBasePathHint": "Tip: Paste full URL (e.g., https://host.com/path/jellyfin) to auto-fill all fields",
+  "lblTestServer": "Test Server",
+  "lblEnableAutoLoginConfig": "Enable config patching for auto-login"
 }

--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/fr.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/fr.json
@@ -161,5 +161,13 @@
   "insufficientSpace": "Votre appareil ne dispose pas d'espace suffisant, veuillez supprimer certaines applications et réessayer...",
   "lblKeepWGTFile": "Conserver le fichier WGT",
   "AuthorMismatch": "Incompatibilité du certificat d'auteur, veuillez signer à nouveau le package avec le certificat correct.",
-  "FixYouTube153": "Correction du plugin YouTube (Erreur 153)"
+  "FixYouTube153": "Correction du plugin YouTube (Erreur 153)",
+  "lblBasePath": "Chemin de base",
+  "lblJellyfinUsername": "Nom d'utilisateur",
+  "lblJellyfinPassword": "Mot de passe",
+  "lblAuthenticate": "Connexion",
+  "lblAutoLoginSettings": "Paramètres de connexion automatique",
+  "lblBasePathHint": "Astuce: Collez l'URL complète (ex: https://host.com/chemin/jellyfin) pour remplir automatiquement",
+  "lblTestServer": "Tester serveur",
+  "lblEnableAutoLoginConfig": "Activer le patch config pour auto-login"
 }

--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/nl.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/nl.json
@@ -161,5 +161,13 @@
   "insufficientSpace": "Er is onvoldoende ruimte op uw apparaat. Verwijder enkele apps en probeer het opnieuw...",
   "lblKeepWGTFile": "WGT-bestand behouden",
   "AuthorMismatch": "Auteurscertificaat komt niet overeen. Onderteken het pakket opnieuw met het juiste certificaat.",
-  "FixYouTube153": "YouTube-plug-in repareren (fout 153)"
+  "FixYouTube153": "YouTube-plug-in repareren (fout 153)",
+  "lblBasePath": "Basispad",
+  "lblJellyfinUsername": "Gebruikersnaam",
+  "lblJellyfinPassword": "Wachtwoord",
+  "lblAuthenticate": "Inloggen",
+  "lblAutoLoginSettings": "Auto-login instellingen",
+  "lblBasePathHint": "Tip: Plak volledige URL (bijv. https://host.com/pad/jellyfin) om alle velden automatisch in te vullen",
+  "lblTestServer": "Test server",
+  "lblEnableAutoLoginConfig": "Config-patching voor auto-login inschakelen"
 }

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -39,6 +39,10 @@ namespace Jellyfin2Samsung.Helpers
         public bool ForceSamsungLogin { get; set; } = false;
         public bool RTLReading { get; set; } = false;
         public string JellyfinIP { get; set; } = "";
+        public string JellyfinBasePath { get; set; } = "";
+        public string JellyfinUsername { get; set; } = "";
+        public string JellyfinPassword { get; set; } = "";
+        public string JellyfinAccessToken { get; set; } = "";
         public string AudioLanguagePreference { get; set; } = "";
         public string SubtitleLanguagePreference { get; set; } = "";
         public bool EnableBackdrops { get; set; } = false;
@@ -82,6 +86,25 @@ namespace Jellyfin2Samsung.Helpers
         public string ReleaseInfo { get; set; } = "https://raw.githubusercontent.com/jeppevinkel/jellyfin-tizen-builds/refs/heads/master/README.md";
         public string CommunityInfo { get; set; } = "https://raw.githubusercontent.com/PatrickSt1991/tizen-community-packages/refs/heads/main/README.md";
         public AppSettings() { }
+
+        /// <summary>
+        /// Gets the full Jellyfin URL including base path for reverse proxy setups.
+        /// Example: https://xxx.seedhost.eu/xxx/jellyfin
+        /// </summary>
+        [JsonIgnore]
+        public string JellyfinFullUrl
+        {
+            get
+            {
+                var baseUrl = JellyfinIP?.TrimEnd('/') ?? "";
+                var basePath = JellyfinBasePath?.Trim('/') ?? "";
+
+                if (string.IsNullOrEmpty(basePath))
+                    return baseUrl;
+
+                return $"{baseUrl}/{basePath}";
+            }
+        }
 
         public void Save()
         {

--- a/Jellyfin2Samsung-CrossOS/Helpers/JellyfinWebPackagePatcher.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/JellyfinWebPackagePatcher.cs
@@ -29,7 +29,7 @@ namespace Jellyfin2Samsung.Helpers
                 await _html.EnsureTizenCorsAsync(ws);
 
                 if (AppSettings.Default.UseServerScripts)
-                    await _html.PatchServerIndexAsync(ws, AppSettings.Default.JellyfinIP);
+                    await _html.PatchServerIndexAsync(ws, AppSettings.Default.JellyfinFullUrl);
 
                 if (AppSettings.Default.PatchYoutubePlugin)
                     await _html.PatchYoutubePlayerAsync(ws);
@@ -44,9 +44,17 @@ namespace Jellyfin2Samsung.Helpers
                 await _html.InjectUserSettingsAsync(ws, userIds);
             }
 
+            // Always inject auto-login credentials if available
+            if (!string.IsNullOrEmpty(AppSettings.Default.JellyfinAccessToken) &&
+                !string.IsNullOrEmpty(AppSettings.Default.JellyfinUserId))
+            {
+                Trace.WriteLine("Injecting auto-login credentials...");
+                await _html.InjectAutoLoginAsync(ws);
+            }
+
             if (AppSettings.Default.EnableDevLogs)
             {
-                Trace.WriteLine("Injecting dev logs...");   
+                Trace.WriteLine("Injecting dev logs...");
                 await _boot.InjectDevLogsAsync(ws);
             }
 

--- a/Jellyfin2Samsung-CrossOS/Views/JellyfinConfigView.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/JellyfinConfigView.axaml
@@ -9,7 +9,7 @@
         x:DataType="viewModels:JellyfinConfigViewModel"
         Title="Jellyfin Config"
         Width="600"
-        Height="900"
+        Height="1050"
         Background="#F5F5F5">
 
 	<Window.Styles>
@@ -115,6 +115,36 @@
 						</Grid>
 
 						<Grid ColumnDefinitions="200,*" ColumnSpacing="12">
+							<TextBlock Grid.Column="0"
+									   Text="{Binding LblBasePath}"
+									   Classes="label"
+									   VerticalAlignment="Center"/>
+							<StackPanel Grid.Column="1" Spacing="4">
+								<TextBox Text="{Binding JellyfinBasePath}"
+										 Watermark="Paste full URL or path: /xxx/jellyfin"
+										 Classes="clean"
+										 HorizontalAlignment="Stretch"/>
+								<TextBlock Text="{Binding LblBasePathHint}"
+										   FontSize="11"
+										   Foreground="#7F8C8D"
+										   TextWrapping="Wrap"/>
+							</StackPanel>
+						</Grid>
+
+						<Grid ColumnDefinitions="200,*" ColumnSpacing="12">
+							<TextBlock Grid.Column="0"
+									   Text="{Binding ServerConnectionStatus}"
+									   Classes="label"
+									   VerticalAlignment="Center"/>
+							<Button Grid.Column="1"
+									Classes="secondary"
+									Content="{Binding LblTestServer}"
+									Command="{Binding TestConnectionCommand}"
+									IsEnabled="{Binding ServerIpSet}"
+									HorizontalAlignment="Left"/>
+						</Grid>
+
+						<Grid ColumnDefinitions="200,*" ColumnSpacing="12">
 							<TextBlock Grid.Column="0" Text="{Binding LblJellyfinServerApi}" Classes="label" VerticalAlignment="Center"/>
 							<TextBox Grid.Column="1"
 									 Text="{Binding JellyfinApiKey}"
@@ -178,6 +208,60 @@
 							<ToggleSwitch Grid.Column="1"
 									IsEnabled="{Binding ApiKeyEnabled}"
 									IsChecked="{Binding PatchYoutubePlugin}"/>
+						</Grid>
+					</StackPanel>
+
+					<Border Height="1" Background="#E8E8E8"/>
+
+					<!-- Auto-Login Settings -->
+					<StackPanel Spacing="12">
+						<TextBlock Text="{Binding LblAutoLoginSettings}"
+								   FontSize="16"
+								   FontWeight="SemiBold"
+								   Foreground="#2C3E50"/>
+
+						<Grid ColumnDefinitions="200,*" ColumnSpacing="12">
+							<TextBlock Grid.Column="0"
+									   Text="{Binding LblJellyfinUsername}"
+									   Classes="label"
+									   VerticalAlignment="Center"/>
+							<TextBox Grid.Column="1"
+									 Text="{Binding JellyfinUsername}"
+									 Watermark="Jellyfin username"
+									 Classes="clean"
+									 HorizontalAlignment="Stretch"/>
+						</Grid>
+
+						<Grid ColumnDefinitions="200,*" ColumnSpacing="12">
+							<TextBlock Grid.Column="0"
+									   Text="{Binding LblJellyfinPassword}"
+									   Classes="label"
+									   VerticalAlignment="Center"/>
+							<TextBox Grid.Column="1"
+									 Text="{Binding JellyfinPassword}"
+									 PasswordChar="*"
+									 Watermark="Jellyfin password"
+									 Classes="clean"
+									 HorizontalAlignment="Stretch"/>
+						</Grid>
+
+						<Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
+							<TextBlock Grid.Column="0"
+									   Text="{Binding AuthenticationStatus}"
+									   Classes="label"
+									   VerticalAlignment="Center"/>
+							<Button Grid.Column="1"
+									Classes="primary"
+									Content="{Binding LblAuthenticate}"
+									Command="{Binding AuthenticateCommand}"
+									IsEnabled="{Binding CanLogin}"/>
+							<Button Grid.Column="2"
+									Classes="secondary"
+									Content="⚙"
+									ToolTip.Tip="{Binding LblEnableAutoLoginConfig}"
+									Command="{Binding EnableAutoLoginConfigCommand}"
+									IsVisible="{Binding IsAuthenticated}"
+									Width="36"/>
 						</Grid>
 					</StackPanel>
 


### PR DESCRIPTION
Add support for Jellyfin servers behind reverse proxies (e.g., seedhost) and automatic login credential injection for Samsung TV installations.

Features:
  - Add Base Path field for reverse proxy URLs (e.g., /xxx/jellyfin)
  - Add JellyfinFullUrl property that combines host:port with base path
  - Add username/password authentication with access token storage
  - Add auto-login injection that pre-populates localStorage credentials
  - Add "Test Connection" button to verify server reachability
  - Add "Login" button to authenticate and store access token

Modified files:
  - Helpers/AppSettings.cs: New properties for base path and credentials
  - Helpers/JellyfinApiClient.cs: AuthenticateAsync() and TestServerConnectionAsync()
  - Helpers/JellyfinHtmlPatcher.cs: InjectAutoLoginAsync() for credential injection
  - Helpers/JellyfinWebPackagePatcher.cs: Integrate auto-login during packaging
  - ViewModels/JellyfinConfigViewModel.cs: UI bindings and commands
  - Views/JellyfinConfigView.axaml: New Auto-Login Settings section
  - Assets/Localization/*.json: Added translations (en, de, fr, nl, da)

Fix for Add reverse proxy path support and auto-login credentials injection

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.

Fixes # (issue number, if applicable)

---

## Type of Change

- [ ] Bug fix (non-breaking change)
- [X] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (please describe):

---

## Checklist

- [X] My code follows the existing project structure and style  
- [ ] I have tested my changes manually  
- [ ] I have added necessary documentation (if applicable)  
- [ ] I have verified that the installer still works with the underlying CLI  

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
