### PR TITLE
feat: add GitHub PAT authentication for API requests

### DIFF
--- a/Jellyfin2Samsung-CrossOS/App.axaml.cs
+++ b/Jellyfin2Samsung-CrossOS/App.axaml.cs
@@ -75,17 +75,20 @@ namespace Jellyfin2Samsung
             services.AddSingleton<IUpdaterService, UpdaterService>();
             services.AddSingleton<IUpdateDialogService, UpdateDialogService>();
 
-            // HttpClient (configured ONCE)
+            // HttpClient (configured ONCE, with GitHub auth if available)
             services.AddSingleton(sp =>
             {
-                var client = new HttpClient
+                var appSettings = sp.GetRequiredService<AppSettings>();
+                var token = Helpers.Core.GitHubAuthHandler.ResolveToken(appSettings);
+                var handler = new Helpers.Core.GitHubAuthHandler(token);
+
+                var client = new HttpClient(handler)
                 {
                     Timeout = TimeSpan.FromSeconds(30)
                 };
 
                 client.DefaultRequestHeaders.UserAgent.ParseAdd("SamsungJellyfinInstaller/1.1");
                 client.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
-
 
                 return client;
             });

--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
@@ -113,6 +113,8 @@
   "lblServerUrl": "Server URL",
   "lblConnectionStatus": "Server Status",
   "lblAdvancedSettings": "Advanced Settings",
+  "lblGitHubToken": "GitHub Token (PAT)",
+  "lblGitHubTokenHint": "Optional. Prevents API rate limiting when fetching releases. Create one at GitHub > Settings > Developer settings > Personal access tokens.",
   "lblTabCss": "CSS Style",
   "lblCssSettings": "Custom CSS Settings",
   "lblCustomCss": "Custom CSS Code",

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -72,6 +72,7 @@ namespace Jellyfin2Samsung.Helpers
         public bool PatchYoutubePlugin { get; set; } = false;
         public string CustomCss { get; set; } = "";
         public bool DarkMode { get; set; } = false;
+        public string GitHubToken { get; set; } = "";
         public string LocalYoutubeServer { get; set; } = string.Empty;
 
         // ----- Updater settings -----

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/GitHubAuthHandler.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/GitHubAuthHandler.cs
@@ -42,12 +42,18 @@ namespace Jellyfin2Samsung.Helpers.Core
         {
             // 1. Explicit setting
             if (!string.IsNullOrWhiteSpace(settings.GitHubToken))
+            {
+                Trace.TraceInformation("[GitHubAuth] Using token from app settings");
                 return settings.GitHubToken.Trim();
+            }
 
             // 2. Environment variable
             var envToken = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
             if (!string.IsNullOrWhiteSpace(envToken))
+            {
+                Trace.TraceInformation("[GitHubAuth] Using token from GITHUB_TOKEN environment variable");
                 return envToken.Trim();
+            }
 
             // 3. GitHub CLI (gh auth token)
             try
@@ -69,7 +75,10 @@ namespace Jellyfin2Samsung.Helpers.Core
                     process.WaitForExit(5000);
 
                     if (process.ExitCode == 0 && !string.IsNullOrWhiteSpace(output))
+                    {
+                        Trace.TraceInformation("[GitHubAuth] Using token from GitHub CLI (gh auth token)");
                         return output;
+                    }
                 }
             }
             catch
@@ -78,6 +87,7 @@ namespace Jellyfin2Samsung.Helpers.Core
             }
 
             // 4. No token available — unauthenticated requests
+            Trace.TraceInformation("[GitHubAuth] No token found — using unauthenticated requests");
             return null;
         }
     }

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/GitHubAuthHandler.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/GitHubAuthHandler.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin2Samsung.Helpers.Core
+{
+    public class GitHubAuthHandler : DelegatingHandler
+    {
+        private readonly string? _token;
+
+        public GitHubAuthHandler(string? token)
+            : base(new HttpClientHandler())
+        {
+            _token = token;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (!string.IsNullOrEmpty(_token) && IsGitHubRequest(request.RequestUri))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+            }
+
+            return base.SendAsync(request, cancellationToken);
+        }
+
+        private static bool IsGitHubRequest(Uri? uri)
+        {
+            if (uri == null) return false;
+            var host = uri.Host;
+            return host.Equals("api.github.com", StringComparison.OrdinalIgnoreCase)
+                || host.Equals("raw.githubusercontent.com", StringComparison.OrdinalIgnoreCase)
+                || host.Equals("github.com", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static string? ResolveToken(AppSettings settings)
+        {
+            // 1. Explicit setting
+            if (!string.IsNullOrWhiteSpace(settings.GitHubToken))
+                return settings.GitHubToken.Trim();
+
+            // 2. Environment variable
+            var envToken = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+            if (!string.IsNullOrWhiteSpace(envToken))
+                return envToken.Trim();
+
+            // 3. GitHub CLI (gh auth token)
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "gh",
+                    Arguments = "auth token",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+
+                using var process = Process.Start(psi);
+                if (process != null)
+                {
+                    var output = process.StandardOutput.ReadToEnd().Trim();
+                    process.WaitForExit(5000);
+
+                    if (process.ExitCode == 0 && !string.IsNullOrWhiteSpace(output))
+                        return output;
+                }
+            }
+            catch
+            {
+                // gh CLI not installed or not authenticated — ignore
+            }
+
+            // 4. No token available — unauthenticated requests
+            return null;
+        }
+    }
+}

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -173,7 +173,10 @@ namespace Jellyfin2Samsung.Services
             {
                 throw new TimeoutException(
                     "GitHub rate limit reached while checking for Tizen SDB.\n\n" +
-                    "Please try again later.",
+                    "To avoid this, set a GitHub Personal Access Token (PAT) in settings,\n" +
+                    "or set the GITHUB_TOKEN environment variable,\n" +
+                    "or install the GitHub CLI (gh) and run 'gh auth login'.\n\n" +
+                    "Alternatively, please try again later.",
                     ex
                 );
             }

--- a/Jellyfin2Samsung-CrossOS/ViewModels/JellyfinConfigViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/JellyfinConfigViewModel.cs
@@ -181,6 +181,12 @@ namespace Jellyfin2Samsung.ViewModels
         private bool darkMode;
 
         [ObservableProperty]
+        private string gitHubToken = string.Empty;
+
+        [ObservableProperty]
+        private bool showGitHubToken = false;
+
+        [ObservableProperty]
         private NetworkInterfaceOption? selectedNetworkInterface;
 
         public ObservableCollection<LanguageOption> AvailableLanguages { get; }
@@ -307,6 +313,9 @@ namespace Jellyfin2Samsung.ViewModels
         public string LblRTL => _localizationService.GetString("lblRTL");
         public string LblKeepWGTFile => _localizationService.GetString("lblKeepWGTFile");
         public string LblSettingsHeader => _localizationService.GetString("lblSettings");
+        public string LblGitHubToken => _localizationService.GetString("lblGitHubToken");
+        public string LblGitHubTokenHint => _localizationService.GetString("lblGitHubTokenHint");
+        public char GitHubTokenPasswordChar => ShowGitHubToken ? '\0' : '*';
 
         public bool CanLogin => ServerValidated &&
                                 !string.IsNullOrWhiteSpace(JellyfinUsername) &&
@@ -435,6 +444,8 @@ namespace Jellyfin2Samsung.ViewModels
             OnPropertyChanged(nameof(LblRTL));
             OnPropertyChanged(nameof(LblKeepWGTFile));
             OnPropertyChanged(nameof(LblSettingsHeader));
+            OnPropertyChanged(nameof(LblGitHubToken));
+            OnPropertyChanged(nameof(LblGitHubTokenHint));
         }
 
         partial void OnAudioLanguagePreferenceChanged(string? value)
@@ -1316,6 +1327,7 @@ namespace Jellyfin2Samsung.ViewModels
             OpenAfterInstall = AppSettings.Default.OpenAfterInstall;
             KeepWGTFile = AppSettings.Default.KeepWGTFile;
             DarkMode = AppSettings.Default.DarkMode;
+            GitHubToken = AppSettings.Default.GitHubToken ?? string.Empty;
         }
 
         private async Task LoadNetworkInterfacesAsync()
@@ -1479,6 +1491,17 @@ namespace Jellyfin2Samsung.ViewModels
         partial void OnDarkModeChanged(bool value)
         {
             _themeService.SetTheme(value);
+        }
+
+        partial void OnGitHubTokenChanged(string value)
+        {
+            AppSettings.Default.GitHubToken = value;
+            AppSettings.Default.Save();
+        }
+
+        partial void OnShowGitHubTokenChanged(bool value)
+        {
+            OnPropertyChanged(nameof(GitHubTokenPasswordChar));
         }
 
         // ========== End Main Settings Methods ==========

--- a/Jellyfin2Samsung-CrossOS/Views/JellyfinConfigView.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/JellyfinConfigView.axaml
@@ -142,6 +142,41 @@
 											  HorizontalAlignment="Stretch"/>
 								</Grid>
 
+								<!-- GitHub Token (PAT) -->
+								<Grid ColumnDefinitions="180,*" ColumnSpacing="12">
+									<TextBlock Grid.Column="0"
+											   Text="{Binding LblGitHubToken}"
+											   Classes="label"
+											   VerticalAlignment="Center"/>
+									<Grid Grid.Column="1" ColumnDefinitions="*,Auto" ColumnSpacing="8">
+										<TextBox Grid.Column="0"
+												 Text="{Binding GitHubToken}"
+												 PasswordChar="{Binding GitHubTokenPasswordChar}"
+												 Watermark="ghp_xxxxxxxxxxxxxxxxxxxx"
+												 Classes="clean"
+												 HorizontalAlignment="Stretch"/>
+										<ToggleButton Grid.Column="1"
+													  IsChecked="{Binding ShowGitHubToken}"
+													  VerticalAlignment="Center"
+													  Width="36"
+													  Height="36"
+													  CornerRadius="4"
+													  Padding="0"
+													  ToolTip.Tip="Show/Hide token">
+											<Panel>
+												<fa:SymbolIcon Symbol="View" Width="16" Height="16" IsVisible="{Binding !ShowGitHubToken}"/>
+												<fa:SymbolIcon Symbol="Cancel" Width="16" Height="16" IsVisible="{Binding ShowGitHubToken}"/>
+											</Panel>
+										</ToggleButton>
+									</Grid>
+								</Grid>
+								<TextBlock Text="{Binding LblGitHubTokenHint}"
+										   FontSize="11"
+										   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+										   FontStyle="Italic"
+										   TextWrapping="Wrap"
+										   Margin="180,0,0,0"/>
+
 							</StackPanel>
 
 							<Border Height="1" Background="{DynamicResource SystemControlForegroundBaseMediumLowBrush}" Margin="0,4"/>


### PR DESCRIPTION
# Pull Request Template

## Branch
- [x] I branched off beta (not master) to develop this feature/fix

## Description

Adds optional GitHub Personal Access Token (PAT) authentication to avoid API rate limiting when fetching releases. The token is resolved from three sources in priority order:

1. App settings (`GitHubToken`)
2. `GITHUB_TOKEN` environment variable
3. GitHub CLI (`gh auth token`)

Also improves the rate limit error message with hints on how to configure a PAT, and adds trace logging so users can see which token source was used in the debug log.

Related issues (all closed, this PR provides a proper long-term fix via authenticated requests):
- Relates to #287 — Custom WGT option missing when GitHub rate limit is reached
- Relates to #235 — Initialization failed due to rate limiting
- Relates to #236 — Catch rate limit exception during initialization
- Relates to #170 — Fix Rate Limit

---

## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (please describe):

---

## Checklist

- [x] My code follows the existing project structure and style
- [x] I have tested my changes manually
- [ ] I have added necessary documentation (if applicable)
- [x] I have verified that the installer still works with the underlying CLI

---

## Additional Notes

- Token is only attached to requests targeting `api.github.com`, `raw.githubusercontent.com`, and `github.com`
- When no token is configured, the app continues to work with unauthenticated requests (existing behavior)
- Debug logs now show `[GitHubAuth]` entries indicating which token source was used