### PR TITLE
fix: missing font

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -28,6 +28,8 @@ let
       fontconfig
       freetype
       libGL
+      dejavu_fonts
+      freefont_ttf
 
       # X11 tools 
       xorg.libX11


### PR DESCRIPTION
## Branch
- [x] I branched off beta (not master) to develop this feature/fix

## Description

Cannot run without the font missing.
```
Unhandled exception. System.InvalidOperationException: Default font family name can't be null or empty.
   at Avalonia.Media.FontManager.GetDefaultFontFamilyName(FontManagerOptions options)
   at Avalonia.Media.FontManager..ctor(IFontManagerImpl platformImpl)
   at Avalonia.Media.FontManager.get_Current()
   at Avalonia.AppBuilder.<>c__DisplayClass71_0.<ConfigureFonts>b__0(AppBuilder appBuilder)
   at Avalonia.AppBuilder.SetupUnsafe()
   at Avalonia.AppBuilder.Setup()
   at Avalonia.AppBuilder.SetupWithLifetime(IApplicationLifetime lifetime)
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime(AppBuilder builder, String[] args, Action`1 lifetimeBuilder)
   at Jellyfin2Samsung.Program.Main(String[] args) in Samsung-Jellyfin-Installer/Jellyfin2Samsung-CrossOS/Program.cs:line 25
```

## Fixes
Adds missing packages to the nix shell.

---

## Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (please describe):

---

## Checklist

- [x] My code follows the existing project structure and style  
- [x] I have tested my changes manually  
- [x] I have added necessary documentation (if applicable)  
- [x] I have verified that the installer still works with the underlying CLI  