### PR TITLE
Bug fixes v2.2.09

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -85,7 +85,7 @@ namespace Jellyfin2Samsung.Helpers
         // ----- Application-scoped settings (readonly at runtime) -----
         public string ReleasesUrl { get; set; } = "https://api.github.com/repos/jeppevinkel/jellyfin-tizen-builds/releases";
         public string AuthorEndpoint { get; set; } = "https://dev.tizen.samsung.com/apis/v2/authors";
-        public string AppVersion { get; set; } = "v2.2.0.8";
+        public string AppVersion { get; set; } = "v2.2.0.9";
         public string TizenSdb { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-sdb/releases";
         public string JellyfinAvRelease { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-jellyfin-avplay/releases";
         public string JellyfinAvReleaseFork { get; set; } = "https://api.github.com/repos/asamahy/tizen-jellyfin-avplay/releases";

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/GitHubAuthHandler.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/GitHubAuthHandler.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Security;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,9 +14,37 @@ namespace Jellyfin2Samsung.Helpers.Core
         private readonly string? _token;
 
         public GitHubAuthHandler(string? token)
-            : base(new HttpClientHandler())
+            : base(CreateInnerHandler())
         {
             _token = token;
+        }
+
+        private static HttpClientHandler CreateInnerHandler()
+        {
+            var handler = new HttpClientHandler();
+
+
+            if (!OperatingSystem.IsWindows() && !OperatingSystem.IsMacOS())
+            {
+                handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) =>
+                {
+                    if (errors == SslPolicyErrors.None)
+                        return true;
+
+                    var host = message.RequestUri?.Host ?? string.Empty;
+                    if (host.EndsWith("samsung.com", StringComparison.OrdinalIgnoreCase) ||
+                        host.EndsWith("samsungqbe.com", StringComparison.OrdinalIgnoreCase) ||
+                        host.EndsWith("tizen.org", StringComparison.OrdinalIgnoreCase))
+                    {
+                        Trace.TraceWarning($"[SSL] Accepting Samsung cert with validation issue on Linux: {host} ({errors})");
+                        return true;
+                    }
+
+                    return false;
+                };
+            }
+
+            return handler;
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/GitHubAuthHandler.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/GitHubAuthHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
@@ -17,7 +18,7 @@ namespace Jellyfin2Samsung.Helpers.Core
             _token = token;
         }
 
-        protected override Task<HttpResponseMessage> SendAsync(
+        protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
@@ -26,7 +27,23 @@ namespace Jellyfin2Samsung.Helpers.Core
                 request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
             }
 
-            return base.SendAsync(request, cancellationToken);
+            var response = await base.SendAsync(request, cancellationToken);
+
+            // Token is expired or revoked — retry unauthenticated for public endpoints
+            if (response.StatusCode == HttpStatusCode.Unauthorized &&
+                request.Headers.Authorization != null)
+            {
+                Trace.TraceWarning("[GitHubAuth] Token rejected (401) — retrying without authorization");
+                var retry = new HttpRequestMessage(request.Method, request.RequestUri);
+                foreach (var header in request.Headers)
+                {
+                    if (!string.Equals(header.Key, "Authorization", StringComparison.OrdinalIgnoreCase))
+                        retry.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+                response = await base.SendAsync(retry, cancellationToken);
+            }
+
+            return response;
         }
 
         private static bool IsGitHubRequest(Uri? uri)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 | Channel    | Version                                                             | Notes                        |
 |------------|---------------------------------------------------------------------|------------------------------|
 | **Stable** | [v2.2.0.8](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases/tag/v2.2.0.8)                                        | Recommended for most users   |
-| **Beta**   | [N/A](#)                                            | Includes new features        |
+| **Beta**   | [v2.2.0.9-beta](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases/tag/v2.2.0.9-beta)                                            | Includes new features        |
 
 <!-- versions:end -->
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@
 
 | Channel    | Version                                                             | Notes                        |
 |------------|---------------------------------------------------------------------|------------------------------|
-| **Stable** | [v2.2.0.7](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases/tag/v2.2.0.7)                                        | Recommended for most users   |
-| **Beta**   | [v2.2.0.8-beta](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases/tag/v2.2.0.8-beta)                                            | Includes new features        |
+| **Stable** | [v2.2.0.8](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases/tag/v2.2.0.8)                                        | Recommended for most users   |
+| **Beta**   | [N/A](#)                                            | Includes new features        |
 
 <!-- versions:end -->
 

--- a/shell.nix
+++ b/shell.nix
@@ -28,6 +28,8 @@ let
       fontconfig
       freetype
       libGL
+      dejavu_fonts
+      freefont_ttf
 
       # X11 tools 
       xorg.libX11


### PR DESCRIPTION
# Pull Request Template

## Branch
- [x] I branched off beta (not master) to develop this feature/fix

## Description
- Arch Linux's CA bundle (ca-certificates package) doesn't include Samsung's intermediate CA for svdca.samsungqbe.com. Windows auto-downloads missing intermediates from Microsoft's Certificate Trust List, so it works there. The browser-based Samsung OAuth works because the browser has its own trust store.

- Fonts are now added for NixOS

- SDB Packages are no downloaded with and without authorization headers

Fixes #331 #332 #333 

---

## Type of Change

- [x] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

---

## Checklist

- [x] My code follows the existing project structure and style  
- [x] I have tested my changes manually  
- [x] I have added necessary documentation (if applicable)  
- [x] I have verified that the installer still works with the underlying CLI  