### PR TITLE
Added ARM64 binaries

### DIFF
--- a/.github/workflows/beta-prerelease.yml
+++ b/.github/workflows/beta-prerelease.yml
@@ -67,7 +67,7 @@ jobs:
             echo "|----------|--------|-------|"
             echo "| 🍎 macOS (.app + dmg) | ⚠️ Beta | ARM64 + Intel |"
             echo "| 🍎 macOS (CLI) | ⚠️ Beta | Per-arch tar.gz |"
-            echo "| 🐧 Linux | ⚠️ Beta | tar.gz / .deb |"
+            echo "| 🐧 Linux | ⚠️ Beta | x64 + ARM64 (tar.gz / .deb) |"
             echo "| 🪟 Windows | ⚠️ Beta | CI-built |"
           } > RELEASE_NOTES.md
 
@@ -85,16 +85,18 @@ jobs:
           mkdir -p dist
           (cd publish/win-x64 && zip -r "../../dist/${PRODUCT_NAME}-${VERSION_TAG}-win-x64.zip" .)
 
-      # ---------------- LINUX ----------------
+      # ---------------- LINUX (x64 + arm64) ----------------
       - name: Build Linux
         run: |
-          dotnet publish Jellyfin2Samsung-CrossOS/Jellyfin2Samsung.csproj \
-            -c Release -r linux-x64 -p:SelfContained=true \
-            -o publish/linux-x64
-
           mkdir -p dist
-          tar -czf "dist/${PRODUCT_NAME}-${VERSION_TAG}-linux-x64.tar.gz" \
-            -C publish/linux-x64 .
+          for ARCH in x64 arm64; do
+            dotnet publish Jellyfin2Samsung-CrossOS/Jellyfin2Samsung.csproj \
+              -c Release -r linux-$ARCH -p:SelfContained=true \
+              -o publish/linux-$ARCH
+
+            tar -czf "dist/${PRODUCT_NAME}-${VERSION_TAG}-linux-$ARCH.tar.gz" \
+              -C publish/linux-$ARCH .
+          done
 
       # ---------------- LINUX ICON ----------------
       - name: Linux icon
@@ -104,33 +106,39 @@ jobs:
           rsvg-convert -w 256 -h 256 \
             jellyfin-tizen-logo.svg -o jellyfin.png
 
-      # ---------------- DEB ----------------
+      # ---------------- DEB (x64 + arm64) ----------------
       - name: Build .deb
         run: |
           sudo apt-get install -y dpkg-dev
 
-          PKG=deb
-          mkdir -p $PKG/opt/jellyfin2samsung \
-                   $PKG/usr/share/{applications,icons/hicolor/256x256/apps}
+          for ARCH in x64 arm64; do
+            case $ARCH in
+              x64)   DEB_ARCH=amd64 ;;
+              arm64) DEB_ARCH=arm64 ;;
+            esac
 
-          cp -R publish/linux-x64/. $PKG/opt/jellyfin2samsung/
-          chmod +x $PKG/opt/jellyfin2samsung/Jellyfin2Samsung
+            PKG=deb-$ARCH
+            mkdir -p $PKG/opt/jellyfin2samsung \
+                     $PKG/usr/share/{applications,icons/hicolor/256x256/apps}
 
-          # 🔥 quick+dirty: allow writes where your app writes
-          mkdir -p \
-            $PKG/opt/jellyfin2samsung/Logs \
-            $PKG/opt/jellyfin2samsung/Downloads \
-            $PKG/opt/jellyfin2samsung/Assets/TizenSDB \
-            $PKG/opt/jellyfin2samsung/Assets/Certificate
-          chmod -R 777 \
-            $PKG/opt/jellyfin2samsung/Logs \
-            $PKG/opt/jellyfin2samsung/Downloads \
-            $PKG/opt/jellyfin2samsung/Assets/TizenSDB \
-            $PKG/opt/jellyfin2samsung/Assets/Certificate
+            cp -R publish/linux-$ARCH/. $PKG/opt/jellyfin2samsung/
+            chmod +x $PKG/opt/jellyfin2samsung/Jellyfin2Samsung
 
-          cp jellyfin.png $PKG/usr/share/icons/hicolor/256x256/apps/jellyfin2samsung.png
+            # 🔥 quick+dirty: allow writes where your app writes
+            mkdir -p \
+              $PKG/opt/jellyfin2samsung/Logs \
+              $PKG/opt/jellyfin2samsung/Downloads \
+              $PKG/opt/jellyfin2samsung/Assets/TizenSDB \
+              $PKG/opt/jellyfin2samsung/Assets/Certificate
+            chmod -R 777 \
+              $PKG/opt/jellyfin2samsung/Logs \
+              $PKG/opt/jellyfin2samsung/Downloads \
+              $PKG/opt/jellyfin2samsung/Assets/TizenSDB \
+              $PKG/opt/jellyfin2samsung/Assets/Certificate
 
-          cat > $PKG/usr/share/applications/jellyfin2samsung.desktop <<EOF
+            cp jellyfin.png $PKG/usr/share/icons/hicolor/256x256/apps/jellyfin2samsung.png
+
+            cat > $PKG/usr/share/applications/jellyfin2samsung.desktop <<EOF
           [Desktop Entry]
           Name=Jellyfin2Samsung
           Exec=/opt/jellyfin2samsung/Jellyfin2Samsung
@@ -139,17 +147,18 @@ jobs:
           Categories=Utility;
           EOF
 
-          mkdir -p $PKG/DEBIAN
-          cat > $PKG/DEBIAN/control <<EOF
+            mkdir -p $PKG/DEBIAN
+            cat > $PKG/DEBIAN/control <<EOF
           Package: jellyfin2samsung
           Version: ${VERSION}
-          Architecture: amd64
+          Architecture: ${DEB_ARCH}
           Maintainer: MadeByPatrick
           Description: Jellyfin2Samsung
           EOF
 
-          dpkg-deb --build $PKG
-          mv $PKG.deb dist/${PRODUCT_NAME}-${VERSION_TAG}-linux-x64.deb
+            dpkg-deb --build $PKG
+            mv $PKG.deb dist/${PRODUCT_NAME}-${VERSION_TAG}-linux-$ARCH.deb
+          done
 
       # ---------------- RELEASE (UPDATE SAME TAG EVERY COMMIT) ----------------
       - uses: softprops/action-gh-release@v2

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -135,7 +135,7 @@ jobs:
             echo "|----------|--------|-------|"
             echo "| 🍎 macOS (.app + dmg) | ✅ Stable | ARM64 + Intel |"
             echo "| 🍎 macOS (CLI) | ✅ Stable | Per-arch tar.gz |"
-            echo "| 🐧 Linux | ✅ Stable | tar.gz / .deb |"
+            echo "| 🐧 Linux | ✅ Stable | x64 + ARM64 (tar.gz / .deb) |"
             echo "| 🪟 Windows | ✅ Stable | CI-built |"
             echo ""
             echo "---"
@@ -158,15 +158,18 @@ jobs:
           mkdir -p dist
           (cd publish/win-x64 && zip -r "../../dist/${PRODUCT_NAME}-${VERSION_TAG}-win-x64.zip" .)
 
-      # ---------------- LINUX ----------------
+      # ---------------- LINUX (x64 + arm64) ----------------
       - name: Build Linux
         run: |
-          dotnet publish ${PROJECT_DIR}/Jellyfin2Samsung.csproj \
-            -c $CONFIGURATION -r linux-x64 -p:SelfContained=true \
-            -o publish/linux-x64
+          mkdir -p dist
+          for ARCH in x64 arm64; do
+            dotnet publish ${PROJECT_DIR}/Jellyfin2Samsung.csproj \
+              -c $CONFIGURATION -r linux-$ARCH -p:SelfContained=true \
+              -o publish/linux-$ARCH
 
-          tar -czf "dist/${PRODUCT_NAME}-${VERSION_TAG}-linux-x64.tar.gz" \
-            -C publish/linux-x64 .
+            tar -czf "dist/${PRODUCT_NAME}-${VERSION_TAG}-linux-$ARCH.tar.gz" \
+              -C publish/linux-$ARCH .
+          done
 
       # ---------------- LINUX ICON ----------------
       - name: Linux icon
@@ -176,33 +179,39 @@ jobs:
           rsvg-convert -w 256 -h 256 \
             jellyfin-tizen-logo.svg -o jellyfin.png
 
-      # ---------------- DEB ----------------
+      # ---------------- DEB (x64 + arm64) ----------------
       - name: Build .deb
         run: |
           sudo apt-get install -y dpkg-dev
 
-          PKG=deb
-          mkdir -p $PKG/opt/jellyfin2samsung \
-                   $PKG/usr/share/{applications,icons/hicolor/256x256/apps}
+          for ARCH in x64 arm64; do
+            case $ARCH in
+              x64)   DEB_ARCH=amd64 ;;
+              arm64) DEB_ARCH=arm64 ;;
+            esac
 
-          cp -R publish/linux-x64/. $PKG/opt/jellyfin2samsung/
-          chmod +x $PKG/opt/jellyfin2samsung/Jellyfin2Samsung
+            PKG=deb-$ARCH
+            mkdir -p $PKG/opt/jellyfin2samsung \
+                     $PKG/usr/share/{applications,icons/hicolor/256x256/apps}
 
-          # 🔥 quick+dirty: allow writes where your app writes
-          mkdir -p \
-            $PKG/opt/jellyfin2samsung/Logs \
-            $PKG/opt/jellyfin2samsung/Downloads \
-            $PKG/opt/jellyfin2samsung/Assets/TizenSDB \
-            $PKG/opt/jellyfin2samsung/Assets/Certificate
-          chmod -R 777 \
-            $PKG/opt/jellyfin2samsung/Logs \
-            $PKG/opt/jellyfin2samsung/Downloads \
-            $PKG/opt/jellyfin2samsung/Assets/TizenSDB \
-            $PKG/opt/jellyfin2samsung/Assets/Certificate
+            cp -R publish/linux-$ARCH/. $PKG/opt/jellyfin2samsung/
+            chmod +x $PKG/opt/jellyfin2samsung/Jellyfin2Samsung
 
-          cp jellyfin.png $PKG/usr/share/icons/hicolor/256x256/apps/jellyfin2samsung.png
+            # 🔥 quick+dirty: allow writes where your app writes
+            mkdir -p \
+              $PKG/opt/jellyfin2samsung/Logs \
+              $PKG/opt/jellyfin2samsung/Downloads \
+              $PKG/opt/jellyfin2samsung/Assets/TizenSDB \
+              $PKG/opt/jellyfin2samsung/Assets/Certificate
+            chmod -R 777 \
+              $PKG/opt/jellyfin2samsung/Logs \
+              $PKG/opt/jellyfin2samsung/Downloads \
+              $PKG/opt/jellyfin2samsung/Assets/TizenSDB \
+              $PKG/opt/jellyfin2samsung/Assets/Certificate
 
-          cat > $PKG/usr/share/applications/jellyfin2samsung.desktop <<EOF
+            cp jellyfin.png $PKG/usr/share/icons/hicolor/256x256/apps/jellyfin2samsung.png
+
+            cat > $PKG/usr/share/applications/jellyfin2samsung.desktop <<EOF
           [Desktop Entry]
           Name=Jellyfin2Samsung
           Exec=/opt/jellyfin2samsung/Jellyfin2Samsung
@@ -211,17 +220,18 @@ jobs:
           Categories=Utility;
           EOF
 
-          mkdir -p $PKG/DEBIAN
-          cat > $PKG/DEBIAN/control <<EOF
+            mkdir -p $PKG/DEBIAN
+            cat > $PKG/DEBIAN/control <<EOF
           Package: jellyfin2samsung
           Version: ${VERSION}
-          Architecture: amd64
+          Architecture: ${DEB_ARCH}
           Maintainer: MadeByPatrick
           Description: Jellyfin2Samsung
           EOF
 
-          dpkg-deb --build $PKG
-          mv $PKG.deb dist/${PRODUCT_NAME}-${VERSION_TAG}-linux-x64.deb
+            dpkg-deb --build $PKG
+            mv $PKG.deb dist/${PRODUCT_NAME}-${VERSION_TAG}-linux-$ARCH.deb
+          done
 
       # ---------------- CREATE/UPDATE STABLE RELEASE ----------------
       - name: Create/Update GitHub Release (stable)

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -85,7 +85,7 @@ namespace Jellyfin2Samsung.Helpers
         // ----- Application-scoped settings (readonly at runtime) -----
         public string ReleasesUrl { get; set; } = "https://api.github.com/repos/jeppevinkel/jellyfin-tizen-builds/releases";
         public string AuthorEndpoint { get; set; } = "https://dev.tizen.samsung.com/apis/v2/authors";
-        public string AppVersion { get; set; } = "v2.2.0.9";
+        public string AppVersion { get; set; } = "v2.2.1.0";
         public string TizenSdb { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-sdb/releases";
         public string JellyfinAvRelease { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-jellyfin-avplay/releases";
         public string JellyfinAvReleaseFork { get; set; } = "https://api.github.com/repos/asamahy/tizen-jellyfin-avplay/releases";

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/Constants.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/Constants.cs
@@ -108,10 +108,12 @@ namespace Jellyfin2Samsung.Helpers.Core
         public static class PlatformBinaries
         {
             public const string TizenSdbWindowsPattern = "TizenSdb*.exe";
-            public const string TizenSdbLinuxPattern = "TizenSdb*_linux";
+            public const string TizenSdbLinuxX64Pattern = "TizenSdb*_linux-x64";
+            public const string TizenSdbLinuxArm64Pattern = "TizenSdb*_linux-arm64";
             public const string TizenSdbMacOsPattern = "TizenSdb*_macos";
             public const string WindowsExtension = ".exe";
-            public const string LinuxSuffix = "_linux";
+            public const string LinuxX64Suffix = "_linux-x64";
+            public const string LinuxArm64Suffix = "_linux-arm64";
             public const string MacOsSuffix = "_macos";
             public const string EsbuildWindows = "win-x64";
             public const string EsbuildLinux = "linux-x64";

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/PlatformService.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/PlatformService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Jellyfin2Samsung.Helpers.Core
@@ -59,6 +60,11 @@ namespace Jellyfin2Samsung.Helpers.Core
         public static bool IsUnixLike => IsLinux || IsMacOS;
 
         /// <summary>
+        /// Returns true if the current process architecture is ARM64.
+        /// </summary>
+        public static bool IsArm64 => RuntimeInformation.ProcessArchitecture == Architecture.Arm64;
+
+        /// <summary>
         /// Gets the appropriate TizenSdb search pattern for the current platform.
         /// </summary>
         /// <returns>The file search pattern for TizenSdb binary.</returns>
@@ -68,7 +74,9 @@ namespace Jellyfin2Samsung.Helpers.Core
             return CurrentPlatform switch
             {
                 Platform.Windows => Constants.PlatformBinaries.TizenSdbWindowsPattern,
-                Platform.Linux => Constants.PlatformBinaries.TizenSdbLinuxPattern,
+                Platform.Linux => IsArm64
+                    ? Constants.PlatformBinaries.TizenSdbLinuxArm64Pattern
+                    : Constants.PlatformBinaries.TizenSdbLinuxX64Pattern,
                 Platform.MacOS => Constants.PlatformBinaries.TizenSdbMacOsPattern,
                 _ => throw new PlatformNotSupportedException("Unsupported operating system")
             };
@@ -85,7 +93,9 @@ namespace Jellyfin2Samsung.Helpers.Core
             return CurrentPlatform switch
             {
                 Platform.Windows => $"TizenSdb_{version}{Constants.PlatformBinaries.WindowsExtension}",
-                Platform.Linux => $"TizenSdb_{version}{Constants.PlatformBinaries.LinuxSuffix}",
+                Platform.Linux => $"TizenSdb_{version}{(IsArm64
+                    ? Constants.PlatformBinaries.LinuxArm64Suffix
+                    : Constants.PlatformBinaries.LinuxX64Suffix)}",
                 Platform.MacOS => $"TizenSdb_{version}{Constants.PlatformBinaries.MacOsSuffix}",
                 _ => throw new PlatformNotSupportedException("Unsupported operating system")
             };
@@ -101,7 +111,7 @@ namespace Jellyfin2Samsung.Helpers.Core
             return CurrentPlatform switch
             {
                 Platform.Windows => "exe",
-                Platform.Linux => "linux",
+                Platform.Linux => IsArm64 ? "linux-arm64" : "linux-x64",
                 Platform.MacOS => "macos",
                 _ => throw new PlatformNotSupportedException("Unsupported operating system")
             };

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 | Channel    | Version                                                             | Notes                        |
 |------------|---------------------------------------------------------------------|------------------------------|
 | **Stable** | [v2.2.0.9](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases/tag/v2.2.0.9)                                        | Recommended for most users   |
-| **Beta**   | [N/A](#)                                            | Includes new features        |
+| **Beta**   | [v2.2.1.0-beta](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases/tag/v2.2.1.0-beta)                                            | Includes new features        |
 
 <!-- versions:end -->
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@
 
 | Channel    | Version                                                             | Notes                        |
 |------------|---------------------------------------------------------------------|------------------------------|
-| **Stable** | [v2.2.0.8](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases/tag/v2.2.0.8)                                        | Recommended for most users   |
-| **Beta**   | [v2.2.0.9-beta](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases/tag/v2.2.0.9-beta)                                            | Includes new features        |
+| **Stable** | [v2.2.0.9](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases/tag/v2.2.0.9)                                        | Recommended for most users   |
+| **Beta**   | [N/A](#)                                            | Includes new features        |
 
 <!-- versions:end -->
 


### PR DESCRIPTION
# Pull Request Template

## Branch
- [x] I branched off beta (not master) to develop this feature/fix

## Description

Helpers/Core/Constants.cs — replaced the single Linux entries with arch-specific ones:
  - TizenSdbLinuxPattern → TizenSdbLinuxX64Pattern (TizenSdb*_linux-x64) + TizenSdbLinuxArm64Pattern (TizenSdb*_linux-arm64)
  - LinuxSuffix → LinuxX64Suffix (_linux-x64) + LinuxArm64Suffix (_linux-arm64)

  Helpers/Core/PlatformService.cs — added IsArm64 (via RuntimeInformation.ProcessArchitecture) and made the three Linux switch arms branch on it:
  - GetTizenSdbSearchPattern() — picks arm64 vs x64 pattern when scanning for an existing local file
  - GetTizenSdbFileName(version) — picks the correct suffix when naming the saved binary
  - GetAssetPlatformIdentifier() — returns linux-arm64 or linux-x64 so the asset-matching Contains() in TizenInstallerService.DownloadTizenSdbAsync reliably picks the right asset (a plain linux would now match both)

Fixes #335 

---

## Type of Change

- [x] New feature (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

---

## Checklist

- [x] My code follows the existing project structure and style  
- [x] I have tested my changes manually  
- [x] I have added necessary documentation (if applicable)  
- [x] I have verified that the installer still works with the underlying CLI  